### PR TITLE
Use default-features to fix cargo warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 [dependencies]
 ledger_device_sdk = "1.19.4"
 include_gif = "1.2.0"
-serde = {version="1.0.192", default_features = false, features = ["derive"]}
-serde-json-core = { git = "https://github.com/rust-embedded-community/serde-json-core"}
+serde = { version="1.0.192", default-features = false, features = ["derive"] }
+serde-json-core = { git = "https://github.com/rust-embedded-community/serde-json-core" }
 hex = { version = "0.4.3", default-features = false, features = ["serde", "alloc"] }
 numtoa = "0.2.4"
 


### PR DESCRIPTION
Minor fix for a warning that pops up every time during build. This is the warning message: 
```
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `serde` dependency)
```