### PR TITLE
[PoC] Port boilerplate to the new io_framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Ledger"]
 edition = "2021"
 
 [dependencies]
-ledger_device_sdk = "1.27.0"
+ledger_device_sdk = { version="1.27.0", features=["io_new"] }
 include_gif = "1.2.4"
 serde = { version="1.0.192", default-features = false, features = ["derive"] }
 serde-json-core = { git = "https://github.com/rust-embedded-community/serde-json-core" }

--- a/src/handlers/get_version.rs
+++ b/src/handlers/get_version.rs
@@ -16,12 +16,13 @@
  *****************************************************************************/
 use crate::AppSW;
 use core::str::FromStr;
-use ledger_device_sdk::io;
+use ledger_device_sdk::io::{self, Command};
 
-pub fn handler_get_version(comm: &mut io::Comm) -> Result<(), AppSW> {
+pub fn handler_get_version(command: Command) -> Result<io::CommandResponse, AppSW> {
     if let Some((major, minor, patch)) = parse_version_string(env!("CARGO_PKG_VERSION")) {
-        comm.append(&[major, minor, patch]);
-        Ok(())
+        let mut response = command.into_response();
+        response.append(&[major, minor, patch])?;
+        Ok(response)
     } else {
         Err(AppSW::VersionParsingFail)
     }


### PR DESCRIPTION
This PR demonstrates the migration to the `io_new` feature, as implemented in [ledger-device-rust-sdk/io_new](https://github.com/LedgerHQ/ledger-device-rust-sdk/pull/295).

TODO before eventually merging:
- [ ] Replace the first commit with a normal update of the SDK version